### PR TITLE
Fix: handle mono gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,18 +138,18 @@
                 <b>Release</b>
                 <output class="price-output" for="envelope.release"></output>
               </label>
-              <input type="range" name="envelope.release" id="envelope.release" value="128" min="0" max="255" />
+              <input type="range" name="envelope.release" id="envelope.release" value="255" min="0" max="255" />
             </div>
           </div>
 
           <div>
             <p><b>Playmode</b></p>
             <div>
-              <input type="radio" id="sound.playmode.oneshot" name="sound.playmode" value="oneshot" />
+              <input type="radio" id="sound.playmode.oneshot" name="sound.playmode" value="oneshot" checked />
               <label for="sound.playmode.oneshot">Oneshot</label>
             </div>
             <div>
-              <input type="radio" id="sound.playmode.key" name="sound.playmode" value="key" checked />
+              <input type="radio" id="sound.playmode.key" name="sound.playmode" value="key" />
               <label for="sound.playmode.key">Key</label>
             </div>
             <div style="margin-bottom: 1.8em">

--- a/script.js
+++ b/script.js
@@ -219,7 +219,7 @@ async function processAudio(file) {
                 const length = Math.floor(buffer.length / x);
                 let newBuffer;
 
-                if (channelNr === '1') { // Mono
+                if (channelNr === '1' && buffer.numberOfChannels === 2) { // Mono
                     const monoData = new Float32Array(length);
                     for (let j = 0; j < length; j++) {
                         monoData[j] = (buffer.getChannelData(0)[j * x] + buffer.getChannelData(1)[j * x]) / 2;


### PR DESCRIPTION
## Small bug fix

There's currently a bug that prevents selecting mono conversion when mono files are in the batch. In practice, this prevents me from converting a batch of stereo files to mono until I manually determine which is mono.

This PR fixes the bug and updates the ko-2 defaults to better settings.

<img width="1352" height="218" alt="Screenshot 2025-09-30 at 5 16 22 PM" src="https://github.com/user-attachments/assets/cb841a8e-ccfd-47aa-81b9-0cab43db1374" />

## QA

- [x] Single stereo file with stereo selection outputs stereo file
- [x] Single stereo file with mono selection outputs mono file
- [x] Single mono file with stereo selection outputs mono file
- [x] Single mono file with mono selection outputs mono file
- [x] Batch stereo + mono files with stereo selection outputs relative stereo + mono files
- [x] Batch stereo + mono files with mono selection outputs mono files